### PR TITLE
Install j2cli via pip rather than easy_install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx
 RUN apt-get update && \
-    apt-get install --assume-yes python-dev python-setuptools
-RUN easy_install j2cli
+    apt-get install --assume-yes python-dev python-setuptools python-pip
+RUN pip install j2cli
 ADD nginx.conf.j2 /
 ADD docker-entrypoint.sh /
 RUN chmod a+rx /docker-entrypoint.sh


### PR DESCRIPTION
Installing via easy_install resulted in this error:

```
Download error on https://pypi.python.org/simple/j2cli/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661) -- Some packages may not be found!
Couldn't find index page for 'j2cli' (maybe misspelled?)
```