### PR TITLE
add proxy config for flower

### DIFF
--- a/.htpasswd
+++ b/.htpasswd
@@ -1,0 +1,1 @@
+admin:$apr1$DyWBiblT$0r9heotG1sa5lKcSBBRLx/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN apt-get update && \
     apt-get install --assume-yes python-dev python-setuptools python-pip
 ADD nginx-built.conf /
 ADD nginx.conf /
+ADD .htpasswd /
 ADD docker-entrypoint.sh /
 RUN chmod a+rx /docker-entrypoint.sh
 RUN chmod a+rx /nginx.conf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 cp /nginx.conf /etc/nginx/conf.d/default.conf
+cp /.htpasswd /etc/nginx/.htpasswd
 exec "$@"

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,6 +14,11 @@ server {
     location /ap/ {
       proxy_pass http://ap:8080/;
     }
+    location /flower/ {
+      proxy_pass http://backend:5555/;
+      auth_basic  "Restricted";
+      auth_basic_user_file  /etc/nginx/.htpasswd;
+    }
 
     location / {
       proxy_set_header Host $host:$server_port;


### PR DESCRIPTION
@robertavram I think I have everything worked out for this. will send an email, but basically flower has a config option to run at a sub-path, and since the sites are all setup with SSL we can just use nginx basic auth for the proxy endpoint.